### PR TITLE
Update Claude Code CLI baseUrl

### DIFF
--- a/docs/claude-code-cli-setup.md
+++ b/docs/claude-code-cli-setup.md
@@ -33,7 +33,9 @@ The Claude Code CLI provider is already included in the list of available provid
      - **Claude Opus (Latest)** - Uses the `opus` alias for the latest Opus model
      - **Claude Sonnet (Latest)** - Uses the `sonnet` alias for the latest Sonnet model
      - **Custom Model** - Specify a custom model name (e.g., `claude-3-5-sonnet`, `claude-3-opus`, etc.)
-   - **Claude Executable Path**: This field is used for the executable path. Default is `claude`, but you can specify the full path if needed (e.g., `/usr/local/bin/claude`)
+   - **Claude Executable Path**: This field is used for the executable path.
+     The built-in model calls `claude` by default, but you can specify the full
+     path if needed (e.g., `/usr/local/bin/claude`).
    - **No API Key Required**: Claude Code CLI uses your existing Claude authentication, so no API key field is shown
    - **Note**: Temperature and max tokens settings are not supported by Claude Code CLI
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -230,7 +230,8 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     enabled: true,
     isBuiltIn: true,
     displayName: "Claude Code CLI (Local)",
-    baseUrl: "/Users/ben/.claude/local/claude", // Path to claude executable
+    // Default to calling `claude` from PATH. Specify full path in settings if needed.
+    baseUrl: "claude",
     maxTokens: 4096,
   },
   {


### PR DESCRIPTION
## Summary
- default the built-in Claude Code CLI model to run `claude`
- clarify executable path instructions in the setup guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842e36b14f48323afb0cb231aa88f28