### PR TITLE
Remove obsolete Claude CLI fields

### DIFF
--- a/docs/claude-code-cli-setup.md
+++ b/docs/claude-code-cli-setup.md
@@ -35,7 +35,7 @@ The Claude Code CLI provider is already included in the list of available provid
      - **Custom Model** - Specify a custom model name (e.g., `claude-3-5-sonnet`, `claude-3-opus`, etc.)
    - **Claude Executable Path**: This field is used for the executable path. Default is `claude`, but you can specify the full path if needed (e.g., `/usr/local/bin/claude`)
    - **No API Key Required**: Claude Code CLI uses your existing Claude authentication, so no API key field is shown
-   - **Note**: Temperature and max tokens settings are not supported by Claude Code CLI
+   - **Note**: Temperature and max tokens settings are ignored by Claude Code CLI
 
 ### 3. Using Claude Code CLI
 

--- a/src/LLMProviders/claudeCodeCLI.ts
+++ b/src/LLMProviders/claudeCodeCLI.ts
@@ -15,24 +15,18 @@ import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager
 
 export interface ClaudeCodeCLIConfig extends BaseChatModelParams {
   modelName?: string;
-  maxTokens?: number;
-  temperature?: number;
   streaming?: boolean;
   claudeExecutablePath?: string;
 }
 
 export class ChatClaudeCodeCLI extends BaseChatModel {
   modelName: string;
-  maxTokens?: number;
-  temperature?: number;
   streaming: boolean;
   claudeExecutablePath: string;
 
   constructor(config: ClaudeCodeCLIConfig = {}) {
     super(config);
     this.modelName = config.modelName || "sonnet";
-    this.maxTokens = config.maxTokens;
-    this.temperature = config.temperature;
     this.streaming = config.streaming ?? false;
     this.claudeExecutablePath = config.claudeExecutablePath || "claude";
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -231,7 +231,6 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     isBuiltIn: true,
     displayName: "Claude Code CLI (Local)",
     baseUrl: "/Users/ben/.claude/local/claude", // Path to claude executable
-    maxTokens: 4096,
   },
   {
     name: ChatModels.GROK3,


### PR DESCRIPTION
## Summary
- drop `maxTokens` and `temperature` from `ClaudeCodeCLI`
- skip token/temperature config for Claude CLI models
- update default Claude CLI model in constants
- note in docs that these settings are ignored

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842e36e4f548323bf585ddcfcb97bb7